### PR TITLE
chore: add .editorconfig for consistent code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps maintain consistent coding styles for multiple developers working on the same project
+# See https://EditorConfig.org for more information
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{js,ts,tsx,json,yml,yaml}]
+quote_type = single


### PR DESCRIPTION
Adds an .editorconfig file at the root of the workspace to enforce consistent indentation, line endings, charset, and file-specific rules for all contributors.

- 2-space indentation
- LF line endings
- UTF-8 charset
- Trims trailing whitespace (except in markdown)
- Enforces single quotes for JS/TS/JSON/YAML

No application logic is affected.